### PR TITLE
Fix filename in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ scrape_configs:
 - job_name: 'docker-labels-sd'
   file_sd_configs:
   - files:
-    - 'from_docker_labels.json'
+    - 'from-docker-labels.json'
 ```
 
 ## Configure your services


### PR DESCRIPTION
The file used in the `scrape_configs` of prometheus has a wrong name
compared to the previous example.